### PR TITLE
Traduction et classes de commande disccord (base & userOnly)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
         "**/.settings": false,
         "**/.factorypath": false
     },
-    "explorerExclude.backup": null,
+    "explorerExclude.backup": {},
     "java.dependency.syncWithFolderExplorer": true,
     "java.dependency.packagePresentation": "hierarchical",
     "java.debug.logLevel": "verbose",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version  | Supported          |
 | -------  | ------------------ |
-| 2022.x   | :white_check_mark: |
+| 2022.3   | :white_check_mark: |
+| 2022.2   | :white_check_mark: |
 | < 2022.1 | :x:                |
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 | -------  | ------------------ |
 | 2022.3   | :white_check_mark: |
 | 2022.2   | :white_check_mark: |
-| < 2022.2 | :x:                |
+| 2022.1   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 | -------  | ------------------ |
 | 2022.3   | :white_check_mark: |
 | 2022.2   | :white_check_mark: |
-| < 2022.1 | :x:                |
+| < 2022.2 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
-            <version>6.12.1</version>
+            <version>6.13.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/bukkit/BukkitManager.java
+++ b/src/main/java/bukkit/BukkitManager.java
@@ -16,6 +16,7 @@ import events.bukkit.OnPlayerLoggin;
 import events.bukkit.OnServerLoad;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
+import locals.LocalManager;
 import main.WhitelistJe;
 import models.BedrockData;
 import models.JavaData;
@@ -27,10 +28,10 @@ public class BukkitManager {
     private Logger logger;
 
     public BukkitManager(WhitelistJe plugin) {
+        this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
         ISpan process = plugin.getSentryService().findWithuniqueName("onEnable")
                 .startChild("BukkitManager");
 
-        this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
         this.plugin = plugin;
         this.registerEvents(plugin);
         this.registerCommands(plugin);
@@ -43,7 +44,7 @@ public class BukkitManager {
         return Bukkit.getServer();
     }
 
-    public String getServerInfoString() {
+    public String getServerInfoString(String lang) {
         final String ip = Bukkit.getServer().getIp();
         final String version = Bukkit.getServer().getVersion();
         final String description = Bukkit.getServer().getMotd();
@@ -51,22 +52,33 @@ public class BukkitManager {
         final boolean onlineMode = Bukkit.getServer().getOnlineMode();
         final boolean usingWhiteList = Bukkit.getServer().hasWhitelist();
         final boolean forceWhitelist = Bukkit.getServer().isWhitelistEnforced();
-        final String onlineStr = onlineMode ? "`true`" : "`false`";
-        final String fwStr = forceWhitelist ? "`true`" : "`false`";
 
-        final String protJ = this.plugin.getConfigManager().get("portJava", "???");
+        final String portJ = this.plugin.getConfigManager().get("portJava", "???");
         final String portB = this.plugin.getConfigManager().get("portBedrock", "???");
         final String paperMcIp = this.plugin.getConfigManager().get("paperMcIp", "???");
 
+        final LocalManager LOCAL = WhitelistJe.LOCALES;
+        final String portField = LOCAL.translateBy("PORT", lang);
+        final String versionField = LOCAL.translateBy("VERSION", lang);
+        final String onlineField = LOCAL.translateBy("ONLINE_MODE", lang);
+        final String whitelistField = LOCAL.translateBy("WHITELISTED", lang);
+        final String defaultGModefield = LOCAL.translateBy("DEFAULT_GAMEMOD", lang);
+        final String descField = LOCAL.translateBy("DESCRIPTION", lang);
+        final String YES = LOCAL.translateBy("YES", lang);
+        final String NO = LOCAL.translateBy("NO", lang);
+
+        final String onlineStr = onlineMode ? "`" + YES +  "`" : "`" + NO +  "`";
+        final String fwStr = forceWhitelist ? "`" + YES +  "`" : "`" + NO +  "`";
+
         StringBuilder sb = new StringBuilder();
         sb.append("\n\tIp: `" + paperMcIp + "`");
-        sb.append("\n\tPort Java: `" + protJ + "`");
-        sb.append("\n\tPort Bedrock: `" + portB + "`");
-        sb.append("\n\tVersion: `" + version + "`");
-        sb.append("\n\tOnline Mode: `" + onlineStr + "`");
-        sb.append("\n\tWhitelisted: `" + fwStr + "`");
-        sb.append("\n\tDefault Gamemode: `" + gameMode.name() + "`");
-        sb.append("\n\tDescription: `" + description + "`");
+        sb.append("\n\t" + portField + " Java: `" + portJ + "`");
+        sb.append("\n\t" + portField + " Bedrock: `" + portB + "`");
+        sb.append("\n\t" + versionField + " : `" + version + "`");
+        sb.append("\n\t" + onlineField + " : `" + onlineStr + "`");
+        sb.append("\n\t" + whitelistField + " : `" + fwStr + "`");
+        sb.append("\n\t" + defaultGModefield + " : `" + gameMode.name() + "`");
+        sb.append("\n\t" + descField + " : `" + description + "`");
 
         return sb.toString();
     }

--- a/src/main/java/commands/bukkit/ConfirmLinkCmd.java
+++ b/src/main/java/commands/bukkit/ConfirmLinkCmd.java
@@ -23,6 +23,7 @@ public class ConfirmLinkCmd extends PlayerBaseCmd {
 
   public static String acceptId = "linkAccept";
   public static String rejectId = "linkReject";
+  private ConfigManager configs;
 
   public ConfirmLinkCmd(WhitelistJe plugin, String cmdName) {
     super(plugin, cmdName);
@@ -120,7 +121,7 @@ public class ConfirmLinkCmd extends PlayerBaseCmd {
     final String mcUuidLabel = LOCAL.translate("LABEL_MIBECRAFT_UUID");
     final String policy = LOCAL.translate("EMBD_LINK_POLICY");
 
-    final String embedUrl = configs.get("minecrafInfosLink", "https://www.fiverr.com/rvdprojects?up_rollout=true");
+    final String embedUrl = this.configs.get("minecrafInfosLink", "https://www.fiverr.com/rvdprojects?up_rollout=true");
 
     final String jsonEmbeded = """
     {

--- a/src/main/java/commands/discords/BaseCmd.java
+++ b/src/main/java/commands/discords/BaseCmd.java
@@ -1,0 +1,144 @@
+package commands.discords;
+
+import java.util.logging.Logger;
+
+import io.sentry.ITransaction;
+import io.sentry.Sentry;
+import io.sentry.SpanStatus;
+import locals.LocalManager;
+import main.WhitelistJe;
+import models.User;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import services.sentry.SentryService;
+
+public abstract class BaseCmd extends ListenerAdapter {
+
+    protected User user;
+    protected Guild guild;
+    protected Logger logger;
+    protected Member member;
+    protected ITransaction tx;
+    protected WhitelistJe plugin;
+    protected MessageChannel channel;
+    protected SlashCommandEvent event;
+    protected static LocalManager LOCAL = WhitelistJe.LOCALES;
+
+    protected String childClassName;
+    protected String cmdNameTradKey;
+    protected String mainTransactionName;
+    protected String mainOperationName;
+    protected net.dv8tion.jda.api.entities.User eventUser;
+
+    abstract void execute();
+
+    protected BaseCmd(WhitelistJe plugin, String childClassName, String cmdNameTradKey, String mainTransactionName,
+            String mainOperationName) {
+        this.plugin = plugin;
+        this.childClassName = childClassName;
+        this.logger = Logger.getLogger("WJE:" + childClassName);
+        this.cmdNameTradKey = cmdNameTradKey;
+        this.mainTransactionName = mainTransactionName;
+        this.mainOperationName = mainOperationName;
+    }
+
+    @Override
+    public void onSlashCommand(SlashCommandEvent event) {
+        if (!this.isValidToContinue(event)) {
+            return;
+        }
+
+        this.user = null;
+        this.event = event;
+        this.guild = event.getGuild();
+        this.member = event.getMember();
+        this.eventUser = event.getUser();
+        this.channel = event.getChannel();
+        this.setWjeUser();
+
+        ITransaction trx = Sentry.startTransaction(this.mainTransactionName, this.mainOperationName);
+        trx.setData("CommandClass", childClassName);
+        this.tx = trx;
+
+        try {
+            this.execute();
+        } catch (Exception e) {
+            final String reply = LOCAL.translate("CMD_ERROR") + ": " + LOCAL.translate("CONTACT_ADMNIN");
+
+            event.reply(reply).setEphemeral(true).submit(true);
+            tx.setData("error-state", "error");
+            tx.finish(SpanStatus.INTERNAL_ERROR);
+            SentryService.captureEx(e);
+        }
+
+        if (!tx.isFinished()) {
+            tx.setData("finalState", "unkwown");
+            tx.finish(SpanStatus.UNKNOWN);
+        }
+
+    }
+
+    protected final boolean isValidToContinue(SlashCommandEvent event) {
+        return !event.isAcknowledged()
+                && LOCAL.setCheckEventLocal(event.getName(), cmdNameTradKey);
+    }
+
+    protected final boolean isValidButtonToContinue(ButtonClickEvent event) {
+        return !event.isAcknowledged();
+    }
+
+    protected final void setWjeUser() {
+        if (member != null)
+            this.user = User.getFromMember(member);
+    }
+
+    protected final void sendMsgToUser(String msg) {
+        if (eventUser == null) {
+            logger.warning("Undefined User for cmd event");
+            return;
+        }
+
+        this.plugin.getDiscordManager().jda.openPrivateChannelById(eventUser.getId()).queue(channel -> {
+            channel.sendMessage(msg).submit(true);
+        });
+    }
+
+    protected final String translateForUser(String key) {
+        if (user == null) {
+            logger.warning("Undefined User for translate event");
+            return LOCAL.translate(key);
+        }
+
+        return LOCAL.translateBy(key, this.user.getLang());
+    }
+
+    protected final void submitReply(String msg) {
+        this.event.reply(msg).submit(true);
+    }
+
+    protected final Boolean getBoolParam(String paramTradKey) {
+        final OptionMapping option = event.getOption(LOCAL.translate(paramTradKey));
+        return option != null ? option.getAsBoolean() : null;
+    }
+
+    protected final String getStringParam(String paramTradKey) {
+        final OptionMapping option = event.getOption(LOCAL.translate(paramTradKey));
+        return option != null ? option.getAsString() : null;
+    }
+
+    protected final Long getLongParam(String paramTradKey) {
+        final OptionMapping option = event.getOption(LOCAL.translate(paramTradKey));
+        return option != null ? option.getAsLong() : null;
+    }
+
+    protected final Double getDoubleParam(String paramTradKey) {
+        final OptionMapping option = event.getOption(LOCAL.translate(paramTradKey));
+        return option != null ? option.getAsDouble() : null;
+    }
+
+}

--- a/src/main/java/commands/discords/BaseCmd.java
+++ b/src/main/java/commands/discords/BaseCmd.java
@@ -55,14 +55,13 @@ public abstract class BaseCmd extends ListenerAdapter {
             return;
         }
 
-        this.user = null;
         this.event = event;
         this.guild = event.getGuild();
         this.member = event.getMember();
         this.eventUser = event.getUser();
         this.channel = event.getChannel();
-        this.cmdLang = LOCAL.getNextLang();
         this.setWjeUser();
+        this.setCommandLang();
 
         ITransaction trx = Sentry.startTransaction(this.mainTransactionName, this.mainOperationName);
         trx.setData("CommandClass", childClassName);
@@ -89,7 +88,7 @@ public abstract class BaseCmd extends ListenerAdapter {
     /**
      * Checks all langugae eventName to find the current language and
      * prevent multiple event calls.
-     * @param SlashCommandEvent event 
+     * @param SlashCommandEvent event
      * @return Boolean
      */
     protected final boolean isValidToContinue(SlashCommandEvent event) {
@@ -104,6 +103,16 @@ public abstract class BaseCmd extends ListenerAdapter {
     protected final void setWjeUser() {
         if (member != null)
             this.user = User.getFromMember(member);
+        else
+            this.user = null;
+    }
+
+    protected final void setCommandLang() {
+        if (user != null) {
+            this.cmdLang = user.getLang();
+        } else {
+            this.cmdLang = LOCAL.getNextLang();
+        }
     }
 
     protected final void sendMsgToUser(String msg) {
@@ -118,39 +127,11 @@ public abstract class BaseCmd extends ListenerAdapter {
     }
 
     protected final String useTranslator(String key) {
-        if(user != null) {
-            return translateUser(key);
-        }
-        else if (cmdLang != null) {
-            return translateCmd(key);
-        }
-        else {
-            return translate(key);
-        }
-    }
-
-    protected final String translateUser(String key) {
-        if (user == null) {
-            return translate(key);
-        }
-
-        return translateBy(key, this.user.getLang());
-    }
-
-    protected final String translateCmd(String key) {
-        if (this.cmdLang == null) {
-            return translate(key);
-        }
-
         return translateBy(key, this.cmdLang);
     }
 
     protected final String translateBy(String key, String lang) {
         return LOCAL.translateBy(key, lang);
-    }
-
-    protected final String translate(String key) {
-        return LOCAL.translate(key);
     }
 
     protected final void submitReply(String msg) {

--- a/src/main/java/commands/discords/LookupMcPlayerCommand.java
+++ b/src/main/java/commands/discords/LookupMcPlayerCommand.java
@@ -2,96 +2,82 @@ package commands.discords;
 
 import org.json.JSONArray;
 
-import configs.ConfigManager;
-import io.sentry.ITransaction;
-import io.sentry.Sentry;
 import io.sentry.SpanStatus;
-import locals.Lang;
-import locals.LocalManager;
 import main.WhitelistJe;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
 import services.api.PlayerDbApi;
-import services.sentry.SentryService;
 
-public class LookupMcPlayerCommand extends ListenerAdapter {
-    private WhitelistJe main;
-    private ConfigManager configs;
+public class LookupMcPlayerCommand extends BaseCmd {
 
-    public LookupMcPlayerCommand(WhitelistJe main) {
-        this.main = main;
-        this.configs = this.main.getConfigManager();
+    private final static String KEY_CMD_NAME = "CMD_LOOKUP";
+    private final static String KEY_CMD_DESC = "DESC_LOOKUP";
+    private final static String KEY_PARAM_VALUE_LABEL = "PARAM_LOOKUP_LABEL";
+
+    public static void REGISTER_CMD(JDA jda, WhitelistJe plugin) {
+        String cmdName = LOCAL.translate(KEY_CMD_NAME);
+        String cmdDesc = LOCAL.translate(KEY_CMD_DESC);
+        final String valueLabel = LOCAL.translate(KEY_PARAM_VALUE_LABEL);
+
+        jda.addEventListener(new LookupMcPlayerCommand(plugin));
+        jda.upsertCommand(cmdName, cmdDesc)
+            .addOption(OptionType.STRING, "type", "`UUID` || `PSEUDO`", true)
+            .addOption(OptionType.STRING, "value", valueLabel, true)
+            .submit(true);
+}
+
+    public LookupMcPlayerCommand(WhitelistJe plugin) {
+        super(plugin,
+            "LookupMcPlayerCommand",
+            "CMD_LOOKUP",
+            "LookupMcPlayerCommand",
+            "Dig Mc® player json");
     }
 
     @Override
-    public void onSlashCommand(SlashCommandEvent event) {
-        final LocalManager LOCAL = WhitelistJe.LOCALES;
+    protected final void execute() {
 
-        LOCAL.setNextLang(Lang.FR.value);
-        final String frCmdName = LOCAL.translate("CMD_LOOKUP");
-        LOCAL.setNextLang(Lang.EN.value);
-        final String enCmdName = LOCAL.translate("CMD_LOOKUP");
-
-        String lang = "";
-        if (event.getName().equals(frCmdName)) {
-            lang = "fr";
-        }
-        else if (event.getName().equals(enCmdName)) {
-            LOCAL.setNextLang(Lang.EN.value);
-            lang = "en";
-        } 
-
-        LOCAL.nextIsDefault();
-        if(lang.length() < 1)
+        if (!event.getChannel().getType().toString().equals("TEXTONLY_CMD")) {
+            final String reply = LOCAL.translate("MEMBERONLY_CMD");
+            event.reply(reply).setEphemeral(true).submit(true);
+            tx.setData("error-state", "textual reserved");
+            tx.finish(SpanStatus.UNAVAILABLE);
             return;
+        }
 
-        ITransaction tx = Sentry.startTransaction("LookupMcPlayerCommand", "dig Mc® player json");
         String lookupMsg = "";
+        final String type = event.getOption("type").getAsString();
+        final String value = event.getOption("value").getAsString();
 
-        try {
-            final String type = event.getOption("type").getAsString();
-            final String value = event.getOption("value").getAsString();
-
-            if(value.length() < 3) {
-                lookupMsg = "❌**Cette valeur de recherche n'est pas valide...\n Voici des examples: \n\t**" +
-                "`UUID`: [0c003c29-8675-4856-914b-9641e4b6bac3, 00000000-0000-0000-0009-000006D1B380, 2535422189221140]\n\t`PSEUDO`: Alex";
-                event.reply(lookupMsg).setEphemeral(true).submit(true);
-
-                tx.setData("state", "invalid form");
-                tx.finish(SpanStatus.OK);
-                return;
-            }
-
-            JSONArray json = null;
-            if(type.toLowerCase().equals("uuid")) {
-                json = PlayerDbApi.fetchInfosWithUuid(value);
-            }
-            else if(type.toLowerCase().equals("pseudo")) {
-                json = PlayerDbApi.fetchInfosWithPseudo(value);
-            }
-            else {
-                lookupMsg = "❌**Vous devez choisir un type valide [`UUID`, `PSEUDO`]**";
-                event.reply(lookupMsg).setEphemeral(true).submit(true);
-                return;
-            }
-
-            lookupMsg = "------------------------------------------------------\n```json\n" + 
-                json.toString(2) + "\n```" + "------------------------------------------------------";
-
-            
+        if (value.length() < 3) {
+            lookupMsg = "❌**Cette valeur de recherche n'est pas valide...\n Voici des examples: \n\t**" +
+                    "`UUID`: [0c003c29-8675-4856-914b-9641e4b6bac3, 00000000-0000-0000-0009-000006D1B380, 2535422189221140]\n\t`PSEUDO`: Alex";
             event.reply(lookupMsg).setEphemeral(true).submit(true);
 
-            tx.setData("state", "response was sent");
+            tx.setData("state", "invalid form");
             tx.finish(SpanStatus.OK);
-
-        } catch (Exception e) {
-            event.reply("❌**Désoler une erreur est survenu...**").setEphemeral(true).submit(true);
-
-            tx.setThrowable(e);
-            tx.setData("error-state", "error");
-            tx.finish(SpanStatus.INTERNAL_ERROR);
-            SentryService.captureEx(e);
+            return;
         }
 
+        JSONArray json = null;
+        if (type.toLowerCase().equals("uuid")) {
+            json = PlayerDbApi.fetchInfosWithUuid(value);
+        } else if (type.toLowerCase().equals("pseudo")) {
+            json = PlayerDbApi.fetchInfosWithPseudo(value);
+        } else {
+            lookupMsg = "❌**Vous devez choisir un type valide [`UUID`, `PSEUDO`]**";
+            event.reply(lookupMsg).setEphemeral(true).submit(true);
+            return;
+        }
+
+        lookupMsg = "------------------------------------------------------\n```json\n" +
+                json.toString(2) + "\n```" + "------------------------------------------------------";
+
+        event.reply(lookupMsg).setEphemeral(true).submit(true);
+
+        tx.setData("state", "response was sent");
+        tx.finish(SpanStatus.OK);
+
     }
+
 }

--- a/src/main/java/commands/discords/LookupMcPlayerCommand.java
+++ b/src/main/java/commands/discords/LookupMcPlayerCommand.java
@@ -38,7 +38,7 @@ public class LookupMcPlayerCommand extends BaseCmd {
     protected final void execute() {
 
         if (!event.getChannel().getType().toString().equals("TEXTONLY_CMD")) {
-            final String reply = LOCAL.translate("MEMBERONLY_CMD");
+            final String reply = LOCAL.translate("GUILDONLY_CMD");
             event.reply(reply).setEphemeral(true).submit(true);
             tx.setData("error-state", "textual reserved");
             tx.finish(SpanStatus.UNAVAILABLE);

--- a/src/main/java/commands/discords/LookupMcPlayerCommand.java
+++ b/src/main/java/commands/discords/LookupMcPlayerCommand.java
@@ -49,11 +49,15 @@ public class LookupMcPlayerCommand extends BaseCmd {
         final String type = event.getOption("type").getAsString();
         final String value = event.getOption("value").getAsString();
 
-        if (value.length() < 3) {
-            lookupMsg = "❌**Cette valeur de recherche n'est pas valide...\n Voici des examples: \n\t**" +
-                    "`UUID`: [0c003c29-8675-4856-914b-9641e4b6bac3, 00000000-0000-0000-0009-000006D1B380, 2535422189221140]\n\t`PSEUDO`: Alex";
-            event.reply(lookupMsg).setEphemeral(true).submit(true);
+        String errorMsg = useTranslator("LOOKUP_ERROR");
+        final String exempleMsg = useTranslator("SOME_EXAMPLES");
 
+        if (value.length() < 3) {
+            lookupMsg = "❌**" + errorMsg + "\n" + exempleMsg +": \n\t**"
+                    + "`UUID`: [0c003c29-8675-4856-914b-9641e4b6bac3, 00000000-0000-0000-0009-000006D1B380, 2535422189221140]\n\t" 
+                    + "`PSEUDO`: Alex";
+                    
+            event.reply(lookupMsg).setEphemeral(true).submit(true);
             tx.setData("state", "invalid form");
             tx.finish(SpanStatus.OK);
             return;
@@ -65,7 +69,8 @@ public class LookupMcPlayerCommand extends BaseCmd {
         } else if (type.toLowerCase().equals("pseudo")) {
             json = PlayerDbApi.fetchInfosWithPseudo(value);
         } else {
-            lookupMsg = "❌**Vous devez choisir un type valide [`UUID`, `PSEUDO`]**";
+            errorMsg = useTranslator("LOOKUP_PARAM_ERROR");
+            lookupMsg = "❌**" + errorMsg + " [`UUID`, `PSEUDO`]**";
             event.reply(lookupMsg).setEphemeral(true).submit(true);
             return;
         }

--- a/src/main/java/commands/discords/RegisterCommand.java
+++ b/src/main/java/commands/discords/RegisterCommand.java
@@ -68,7 +68,7 @@ public class RegisterCommand extends BaseCmd {
     protected final void execute() {
         
         if (this.member == null) {
-            final String reply = LOCAL.translate("MEMBERONLY_CMD");
+            final String reply = LOCAL.translate("GUILDONLY_CMD");
             event.reply(reply).setEphemeral(true).submit(true);
             tx.setData("error-state", "guild reserved");
             tx.finish(SpanStatus.UNAVAILABLE);

--- a/src/main/java/commands/discords/ServerCommand.java
+++ b/src/main/java/commands/discords/ServerCommand.java
@@ -95,7 +95,7 @@ public class ServerCommand extends BaseCmd {
                     + ":"
                     + (minutes <= 9 ? "0" + minutes : minutes) + " (" + isDay + ")`\n\t" + weather + "\n\n\t");
 
-            if (!configs.get("showSubWorlddMeteo", "false").equals("true")) {
+            if (!this.configs.get("showSubWorlddMeteo", "false").equals("true")) {
                 break;
             }
         }

--- a/src/main/java/commands/discords/SetUserLanguageCmd.java
+++ b/src/main/java/commands/discords/SetUserLanguageCmd.java
@@ -53,7 +53,7 @@ public class SetUserLanguageCmd extends WjeUserOnlyCmd {
         }
 
         sb.delete(0, sb.length());
-        sb.append(useTranslator("LANG_CHANGED") + ": ");
+        sb.append(translateBy("LANG_CHANGED", user.getLang()) + ": ");
         sb.append("`" + oldLang + "` --> `" + user.getLang() + "`");
         
         this.submitReply(sb.toString());

--- a/src/main/java/commands/discords/SetUserLanguageCmd.java
+++ b/src/main/java/commands/discords/SetUserLanguageCmd.java
@@ -38,12 +38,21 @@ public class SetUserLanguageCmd extends WjeUserOnlyCmd {
         final String oldLang = user.getLang();
         final String lang = this.getStringParam(KEY_PARAM_LANG);
 
+        final StringBuilder sb = new StringBuilder();
+        sb.append(translateForUser("LANG_CURRENT") + ": ");
+        sb.append("`" + user.getLang() + "`");
+
+        if(lang == null || oldLang.equals(lang.toUpperCase())) {
+            this.submitReply(sb.toString());
+            return;
+        }
+
         if(lang != null) {
             user.setLang(lang);
             user.saveUser();
         }
 
-        final StringBuilder sb = new StringBuilder();
+        sb.delete(0, sb.length());
         sb.append(translateForUser("LANG_CHANGED") + ": ");
         sb.append("`" + oldLang + "` --> `" + user.getLang() + "`");
         

--- a/src/main/java/commands/discords/SetUserLanguageCmd.java
+++ b/src/main/java/commands/discords/SetUserLanguageCmd.java
@@ -1,0 +1,53 @@
+package commands.discords;
+
+import main.WhitelistJe;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+public class SetUserLanguageCmd extends WjeUserOnlyCmd {
+
+    private final static String KEY_CMD_NAME = "CMD_SETLOCAL";
+    private final static String KEY_CMD_DESC = "DESC_SETLOCAL";
+    private final static String KEY_PARAM_LANG = "PARAM_LOCAL_SETLOCAL";
+    private final static String KEY_PARAM_LANG_LABEL = "PARAM_LOCAL_LABEL";
+
+    public static final void REGISTER_CMD(JDA jda, WhitelistJe plugin) {
+        String cmdName = LOCAL.translate(KEY_CMD_NAME);
+        String cmdDesc = LOCAL.translate(KEY_CMD_DESC);
+        final String localLangParam = LOCAL.translate(KEY_PARAM_LANG);
+        final String localLangLabel = LOCAL.translate(KEY_PARAM_LANG_LABEL);
+
+        // Traduction
+        jda.addEventListener(new SetUserLanguageCmd(plugin));
+        jda.upsertCommand(cmdName, cmdDesc)
+        .addOption(OptionType.STRING, localLangParam, localLangLabel, false)
+            .submit(true);
+    }
+
+    public SetUserLanguageCmd(WhitelistJe plugin) {
+        super(plugin, 
+            "SetUserLanguageCmd",
+            "CMD_SETLOCAL",
+            "SetUserLanguage",
+            "Change local"
+        );
+    }
+
+    @Override
+    protected final void execute() {
+        final String oldLang = user.getLang();
+        final String lang = this.getStringParam(KEY_PARAM_LANG);
+
+        if(lang != null) {
+            user.setLang(lang);
+            user.saveUser();
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append(translateForUser("LANG_CHANGED") + ": ");
+        sb.append("`" + oldLang + "` --> `" + user.getLang() + "`");
+        
+        this.submitReply(sb.toString());
+    }
+
+}

--- a/src/main/java/commands/discords/SetUserLanguageCmd.java
+++ b/src/main/java/commands/discords/SetUserLanguageCmd.java
@@ -11,7 +11,7 @@ public class SetUserLanguageCmd extends WjeUserOnlyCmd {
     private final static String KEY_PARAM_LANG = "PARAM_LOCAL_SETLOCAL";
     private final static String KEY_PARAM_LANG_LABEL = "PARAM_LOCAL_LABEL";
 
-    public static final void REGISTER_CMD(JDA jda, WhitelistJe plugin) {
+    public static void REGISTER_CMD(JDA jda, WhitelistJe plugin) {
         String cmdName = LOCAL.translate(KEY_CMD_NAME);
         String cmdDesc = LOCAL.translate(KEY_CMD_DESC);
         final String localLangParam = LOCAL.translate(KEY_PARAM_LANG);
@@ -25,7 +25,7 @@ public class SetUserLanguageCmd extends WjeUserOnlyCmd {
     }
 
     public SetUserLanguageCmd(WhitelistJe plugin) {
-        super(plugin, 
+        super(plugin,
             "SetUserLanguageCmd",
             "CMD_SETLOCAL",
             "SetUserLanguage",
@@ -39,7 +39,7 @@ public class SetUserLanguageCmd extends WjeUserOnlyCmd {
         final String lang = this.getStringParam(KEY_PARAM_LANG);
 
         final StringBuilder sb = new StringBuilder();
-        sb.append(translateForUser("LANG_CURRENT") + ": ");
+        sb.append(useTranslator("LANG_CURRENT") + ": ");
         sb.append("`" + user.getLang() + "`");
 
         if(lang == null || oldLang.equals(lang.toUpperCase())) {
@@ -53,7 +53,7 @@ public class SetUserLanguageCmd extends WjeUserOnlyCmd {
         }
 
         sb.delete(0, sb.length());
-        sb.append(translateForUser("LANG_CHANGED") + ": ");
+        sb.append(useTranslator("LANG_CHANGED") + ": ");
         sb.append("`" + oldLang + "` --> `" + user.getLang() + "`");
         
         this.submitReply(sb.toString());

--- a/src/main/java/commands/discords/WjeUserOnlyCmd.java
+++ b/src/main/java/commands/discords/WjeUserOnlyCmd.java
@@ -19,21 +19,20 @@ public abstract class WjeUserOnlyCmd extends BaseCmd {
             return;
         }
         
-        this.user = null;
         this.event = event;
         this.guild = event.getGuild();
         this.member = event.getMember();
         this.eventUser = event.getUser();
         this.channel = event.getChannel();
-        this.cmdLang = LOCAL.getNextLang();
         this.setWjeUser();
+        this.setCommandLang();
 
         ITransaction trx = Sentry.startTransaction(this.mainTransactionName, this.mainOperationName);
         trx.setData("CommandClass", childClassName);
         this.tx = trx;
 
         if (this.member == null) {
-            final String reply = useTranslator("MEMBERONLY_CMD");
+            final String reply = useTranslator("GUILDONLY_CMD");
             event.reply(reply).setEphemeral(true).submit(true);
             tx.setData("error-state", "guild reserved");
             tx.finish(SpanStatus.UNAVAILABLE);

--- a/src/main/java/commands/discords/WjeUserOnlyCmd.java
+++ b/src/main/java/commands/discords/WjeUserOnlyCmd.java
@@ -25,6 +25,7 @@ public abstract class WjeUserOnlyCmd extends BaseCmd {
         this.member = event.getMember();
         this.eventUser = event.getUser();
         this.channel = event.getChannel();
+        this.cmdLang = LOCAL.getNextLang();
         this.setWjeUser();
 
         ITransaction trx = Sentry.startTransaction(this.mainTransactionName, this.mainOperationName);
@@ -32,7 +33,7 @@ public abstract class WjeUserOnlyCmd extends BaseCmd {
         this.tx = trx;
 
         if (this.member == null) {
-            final String reply = LOCAL.translate("MEMBERONLY_CMD");
+            final String reply = useTranslator("MEMBERONLY_CMD");
             event.reply(reply).setEphemeral(true).submit(true);
             tx.setData("error-state", "guild reserved");
             tx.finish(SpanStatus.UNAVAILABLE);
@@ -40,7 +41,7 @@ public abstract class WjeUserOnlyCmd extends BaseCmd {
         }
 
         if (this.user == null) {
-            final String reply = LOCAL.translate("USERONLY_CMD");
+            final String reply = useTranslator("USERONLY_CMD");
             event.reply(reply).setEphemeral(true).submit(true);
             tx.setData("error-state", "unregistered");
             tx.finish(SpanStatus.UNAUTHENTICATED);
@@ -50,7 +51,7 @@ public abstract class WjeUserOnlyCmd extends BaseCmd {
         try {
             this.execute();
         } catch (Exception e) {
-            final String reply = LOCAL.translate("CMD_ERROR") + ": " + LOCAL.translate("CONTACT_ADMNIN");
+            final String reply = useTranslator("CMD_ERROR") + ": " + useTranslator("CONTACT_ADMNIN");
 
             event.reply(reply).setEphemeral(true).submit(true);
             tx.setData("error-state", "error");

--- a/src/main/java/commands/discords/WjeUserOnlyCmd.java
+++ b/src/main/java/commands/discords/WjeUserOnlyCmd.java
@@ -1,0 +1,67 @@
+package commands.discords;
+
+import io.sentry.ITransaction;
+import io.sentry.Sentry;
+import io.sentry.SpanStatus;
+import main.WhitelistJe;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import services.sentry.SentryService;
+
+public abstract class WjeUserOnlyCmd extends BaseCmd {
+
+    protected WjeUserOnlyCmd(WhitelistJe plugin, String childClassName, String cmdNameTradKey, String mainTransactionName, String mainOperationName) {
+        super(plugin, childClassName, cmdNameTradKey, mainTransactionName, mainOperationName);
+    }
+
+    @Override
+    public void onSlashCommand(SlashCommandEvent event) {
+        if (!this.isValidToContinue(event)) {
+            return;
+        }
+        
+        this.user = null;
+        this.event = event;
+        this.guild = event.getGuild();
+        this.member = event.getMember();
+        this.eventUser = event.getUser();
+        this.channel = event.getChannel();
+        this.setWjeUser();
+
+        ITransaction trx = Sentry.startTransaction(this.mainTransactionName, this.mainOperationName);
+        trx.setData("CommandClass", childClassName);
+        this.tx = trx;
+
+        if (this.member == null) {
+            final String reply = LOCAL.translate("MEMBERONLY_CMD");
+            event.reply(reply).setEphemeral(true).submit(true);
+            tx.setData("error-state", "guild reserved");
+            tx.finish(SpanStatus.UNAVAILABLE);
+            return;
+        }
+
+        if (this.user == null) {
+            final String reply = LOCAL.translate("USERONLY_CMD");
+            event.reply(reply).setEphemeral(true).submit(true);
+            tx.setData("error-state", "unregistered");
+            tx.finish(SpanStatus.UNAUTHENTICATED);
+            return;
+        }
+
+        try {
+            this.execute();
+        } catch (Exception e) {
+            final String reply = LOCAL.translate("CMD_ERROR") + ": " + LOCAL.translate("CONTACT_ADMNIN");
+
+            event.reply(reply).setEphemeral(true).submit(true);
+            tx.setData("error-state", "error");
+            tx.finish(SpanStatus.INTERNAL_ERROR);
+            SentryService.captureEx(e);
+        }
+
+        if (!tx.isFinished()) {
+            tx.setData("finalState", "unkwown");
+            tx.finish(SpanStatus.UNKNOWN);
+        }
+    }
+
+}

--- a/src/main/java/dao/DaoManager.java
+++ b/src/main/java/dao/DaoManager.java
@@ -18,13 +18,13 @@ public class DaoManager {
     protected static JavaDataDao javaDataDao = null;
     private Logger logger;
 
-    public DaoManager(ConfigManager configs, WhitelistJe plugin) {
+    public DaoManager(WhitelistJe plugin) {
         try {
             ISpan process = plugin.getSentryService().findWithuniqueName("onEnable")
                 .startChild("DaoManager");
 
             this.logger = Logger.getLogger("WJE:" + getClass().getSimpleName());
-            dataSource = DbPoolFactory.getMysqlPool(configs);
+            dataSource = DbPoolFactory.getMysqlPool(plugin.getConfigManager());
 
             process.setStatus(SpanStatus.OK);
             process.finish();

--- a/src/main/java/discord/DiscordManager.java
+++ b/src/main/java/discord/DiscordManager.java
@@ -27,17 +27,16 @@ import services.sentry.SentryService;
 
 public class DiscordManager {
     public WhitelistJe plugin;
-    private ConfigManager configs;
     public JDA jda;
 
+    private Guild guild;
     private Logger logger;
-    private String servername = "Discord® Server";
-    private boolean isPrivateBot = true;
+    private String ownerId;
     private String guildId;
     private String inviteUrl;
-	private Guild guild;
-    private String ownerId;
-    static private ConfigManager Configs = new ConfigManager();
+    private ConfigManager configs;
+    private boolean isPrivateBot = true;
+    private String servername = "Discord® Server";
 
     public DiscordManager(WhitelistJe plugin) {
         ISpan process = plugin.getSentryService().findWithuniqueName("onEnable")
@@ -45,6 +44,8 @@ public class DiscordManager {
 
         this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
         this.plugin = plugin;
+        this.configs = plugin.getConfigManager();
+
         this.connect();
         this.setupCommands();
         this.setupListener();

--- a/src/main/java/discord/DiscordManager.java
+++ b/src/main/java/discord/DiscordManager.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import commands.discords.LookupMcPlayerCommand;
 import commands.discords.RegisterCommand;
 import commands.discords.ServerCommand;
+import commands.discords.SetUserLanguageCmd;
 import configs.ConfigManager;
 import events.discords.OnUserConfirm;
 import io.sentry.ISpan;
@@ -20,7 +21,6 @@ import main.WhitelistJe;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import services.sentry.SentryService;
@@ -125,75 +125,19 @@ public class DiscordManager {
         final LocalManager LOCAL = WhitelistJe.LOCALES;
 
         try {
-            // FRENCH COMMAND
-            LOCAL.setNextLang(Lang.FR.value);
+            String[] langArr = {Lang.FR.value, Lang.EN.value, Lang.ES.value};
 
-            String srvCmdName = LOCAL.translate("CMD_SERVER");
-            String srvCmdDesc = LOCAL.translate("DESC_SERVER");
-            
-            String rgstrCmdName = LOCAL.translate("CMD_REGISTER");
-            String rgstrCmdDesc = LOCAL.translate("DESC_REGISTR");
-            String paramJ = LOCAL.translate("PARAM_PJAVA");
-            String paramB = LOCAL.translate("PARAM_PBEDR");
-            String paramLabelJ = LOCAL.translate("PARAM_REGISTR_LABELJ");
-            String paramLabelB = LOCAL.translate("PARAM_REGISTR_LABELB");
-
-            String lookCmdName = LOCAL.translate("CMD_LOOKUP");
-            String lookDesc = LOCAL.translate("DESC_LOOKUP");
-            String valueLabel = LOCAL.translate("PARAM_LOOKUP_LABEL");
-
-            // Serveur
-            jda.addEventListener(new ServerCommand(plugin));
-            jda.upsertCommand(srvCmdName, srvCmdDesc)
-            .submit(true);
-
-            // Enregistrer
-            jda.addEventListener(new RegisterCommand(plugin));
-            jda.upsertCommand(rgstrCmdName, rgstrCmdDesc)
-            .addOption(OptionType.STRING, paramJ, paramLabelJ, false)
-            .addOption(OptionType.STRING, paramB, paramLabelB, false)
-            .submit(true);
-
-            // Recherche
-            jda.addEventListener(new LookupMcPlayerCommand(plugin));
-            jda.upsertCommand(lookCmdName, lookDesc)
-                .addOption(OptionType.STRING, "type", "`UUID` || `PSEUDO`", true)
-                .addOption(OptionType.STRING, "value", valueLabel, true)
-                .submit(true);
-
-
-            // ENGLISH COMMANDS
-            LOCAL.setNextLang(Lang.EN.value);
-
-            srvCmdName = LOCAL.translate("CMD_SERVER");
-            srvCmdDesc = LOCAL.translate("DESC_SERVER");
-
-            rgstrCmdName = LOCAL.translate("CMD_REGISTER");
-            rgstrCmdDesc = LOCAL.translate("DESC_REGISTR");
-            paramJ = LOCAL.translate("PARAM_PJAVA");
-            paramB = LOCAL.translate("PARAM_PBEDR");
-            paramLabelJ = LOCAL.translate("PARAM_REGISTR_LABELJ");
-            paramLabelB = LOCAL.translate("PARAM_REGISTR_LABELB");
-
-            lookCmdName = LOCAL.translate("CMD_LOOKUP");
-            lookDesc = LOCAL.translate("DESC_LOOKUP");
-            valueLabel = LOCAL.translate("PARAM_LOOKUP_LABEL");
-
-            // Server
-            jda.upsertCommand(srvCmdName, srvCmdDesc)
-            .submit(true);
-
-            // Register
-            jda.upsertCommand(rgstrCmdName, rgstrCmdDesc)
-            .addOption(OptionType.STRING, paramJ, paramLabelJ, false)
-            .addOption(OptionType.STRING, paramB, paramLabelB, false)
-            .submit(true);
-
-            // Search
-            jda.upsertCommand(lookCmdName, lookDesc)
-                .addOption(OptionType.STRING, "type", "`UUID` || `PSEUDO`", true)
-                .addOption(OptionType.STRING, "value", valueLabel, true)
-                .submit(true);
+            for (int i = 0; i < langArr.length; i++) {
+                LOCAL.setNextLang(langArr[i]);
+                // Serveur
+                ServerCommand.REGISTER_CMD(jda, plugin);
+                // Enregistrer
+                RegisterCommand.REGISTER_CMD(jda, plugin);
+                //Recherche
+                LookupMcPlayerCommand.REGISTER_CMD(jda, plugin);
+                // User transaltion
+                SetUserLanguageCmd.REGISTER_CMD(jda, plugin);
+            }
             
         } catch (Exception e) {
             this.logger.warning("Failed to initialize DS commands correctly");

--- a/src/main/java/discord/DiscordManager.java
+++ b/src/main/java/discord/DiscordManager.java
@@ -27,6 +27,7 @@ import services.sentry.SentryService;
 
 public class DiscordManager {
     public WhitelistJe plugin;
+    private ConfigManager configs;
     public JDA jda;
 
     private Logger logger;
@@ -56,7 +57,7 @@ public class DiscordManager {
         ISpan process = plugin.getSentryService().findWithuniqueName("onEnable")
         .startChild("DiscordManager.connect");
         try {
-            jda = JDABuilder.create(Configs.get("discordBotToken", null),
+            jda = JDABuilder.create(this.configs.get("discordBotToken", null),
                     EnumSet.allOf(GatewayIntent.class))
                     .build()
                     .awaitReady();
@@ -97,14 +98,14 @@ public class DiscordManager {
                 this.logger.warning("Discord bot's tokken already in use on another DS !!!");
             }
 
-            guildId = Configs.get("discordServerId", null);
+            guildId = this.configs.get("discordServerId", null);
             this.guild = jda.getGuildById(guildId);
             this.servername = this.guild.getName();
             this.guildId = this.guild.getId();
             this.inviteUrl = this.setInvite();
             this.ownerId = this.guild.getOwnerId();
         } catch (Exception e) {
-            this.logger.warning("Discord bot's not authorized into this guild. (Check: " + Configs.getClass().getSimpleName() +")");
+            this.logger.warning("Discord bot's not authorized into this guild. (Check: " + this.configs.getClass().getSimpleName() +")");
         }
     }
 

--- a/src/main/java/discord/GuildManager.java
+++ b/src/main/java/discord/GuildManager.java
@@ -29,13 +29,13 @@ public class GuildManager {
     private String devRoleId;
     private String welcomeChannelId;
 
-    public GuildManager(Guild guild, WhitelistJe plugin) {
+    public GuildManager(WhitelistJe plugin) {
+        this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
         ISpan process = plugin.getSentryService().findWithuniqueName("onEnable")
                 .startChild("GuildManager");
-
-        this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
-        this.configManager = new ConfigManager();
-        this.guild = guild;
+        
+        this.configManager = plugin.getConfigManager();
+        this.guild = plugin.getDiscordManager().getGuild();
         this.setupIds();
 
         process.setStatus(SpanStatus.OK);

--- a/src/main/java/events/bukkit/OnServerLoad.java
+++ b/src/main/java/events/bukkit/OnServerLoad.java
@@ -1,29 +1,27 @@
 package events.bukkit;
 
-import java.util.logging.Logger;
-
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerLoadEvent;
 
+import locals.LocalManager;
 import main.WhitelistJe;
 
 public class OnServerLoad implements Listener {
-    private WhitelistJe main;
-    private Logger logger;
+    private WhitelistJe plugin;
 
-    public OnServerLoad(WhitelistJe main) {
-        this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
-        this.main = main;
+    public OnServerLoad(WhitelistJe plugin) {
+        this.plugin = plugin;
     }
 
     @EventHandler
     public void onServerLoad(ServerLoadEvent event) {
+        LocalManager LOCAL = WhitelistJe.LOCALES;
         StringBuilder sb = new StringBuilder();
-        sb.append("**Le serveur est up and running boyyssss!** ");
-        sb.append(this.main.getBukkitManager().getServerInfoString());
+        sb.append("**" + LOCAL.translate("SERVER_IS_UP") + "** ");
+        sb.append(this.plugin.getBukkitManager().getServerInfoString(LOCAL.getNextLang()));
         
-        this.main.getGuildManager().getAdminChannel()
+        this.plugin.getGuildManager().getAdminChannel()
             .sendMessage(sb.toString()).submit(true);
     }
 

--- a/src/main/java/helpers/Helper.java
+++ b/src/main/java/helpers/Helper.java
@@ -28,6 +28,14 @@ public class Helper {
     public static long dayMSLONG = 86400000;
     public static long hourMSLONG = dayMSLONG / 24;
 
+    public static String capitalize(String str) {
+        String firstLetter = str.substring(0, 1);
+        final String remainingLetters = str.substring(1, str.length());
+
+        firstLetter = firstLetter.toUpperCase();
+        return firstLetter + remainingLetters;
+    }
+
     public static String decimalToHex(Long decimal) {
         if(decimal == null) {
             return null;

--- a/src/main/java/locals/En.java
+++ b/src/main/java/locals/En.java
@@ -2,15 +2,33 @@ package locals;
 
 public enum En {
     //GLOBAL
+    YES("Yes"),
+    NO("No"),
     RAINY("rainy"),
     SUNNY("sunny"),
+    STORMY("stormy"),
+    DAY("Day"),
+    NIGHT("Night"),
     NAME("name"),
-    VERSION("version"),
+    VERSION("Version"),
     ISACTIVE("is active"),
     ISINACTIVE("is inactive"),
     DOREGISTER("Register on the Discord® server"),
     MINECRAFT_ALREADYREGISTERED("This account is already confirmed..."),
     ACCOUNTSINFOS("Accounts informations"),
+    INFORMATION("Informations"),
+    SERVER("Server"),
+    WORLDS("Worlds"),
+    DEVS("Developers"),
+    PORT("Port"),
+    ONLINE_MODE("Online mode"),
+    WHITELISTED("Whitelisted"),
+    DEFAULT_GAMEMOD("Default gamemode"),
+    DESCRIPTION("Description"),
+    CONNECTED_USER("Connected user"),
+    CONNECTED_USERS("Connected users"),
+    SERVER_ACTIVITIES("🌿 Server activities"),
+    TIME_METEO("Meteo and time"),
 
     //REPLIES
     LANG_CHANGED("Your language was changed"),
@@ -84,8 +102,11 @@ public enum En {
 
     //ACL
     TEXTONLY_CMD("❌ This command is available only through textual channels."),
-    MEMBERONLY_CMD("❌ This command is available only through textual guild channels using this."),
+    GUILDONLY_CMD("❌ This command is available only through textual guild channels using this."),
     USERONLY_CMD("❌ This command id reserved for Discord® registered users only."),
+
+    //MISC
+    SERVER_IS_UP("The server is up and running boyyssss!"),
 
     ;
 

--- a/src/main/java/locals/En.java
+++ b/src/main/java/locals/En.java
@@ -14,6 +14,7 @@ public enum En {
 
     //REPLIES
     LANG_CHANGED("Your language was changed"),
+    LANG_CURRENT("You current language is"),
 
     //TITLES
     TITLE_ACCOUNT_CONFIRM("Your accounts confirmation"),

--- a/src/main/java/locals/En.java
+++ b/src/main/java/locals/En.java
@@ -29,6 +29,7 @@ public enum En {
     CONNECTED_USERS("Connected users"),
     SERVER_ACTIVITIES("🌿 Server activities"),
     TIME_METEO("Meteo and time"),
+    SOME_EXAMPLES("Here's some examples"),
 
     //REPLIES
     LANG_CHANGED("Your language was changed"),
@@ -77,6 +78,8 @@ public enum En {
     CHECK_LOGS("**Check your `log` files!!!!**"),
     NOTREGISTERED("Your registration could not be fetched..."),
     CMD_ERROR("❌ Sorry... an error as occured during this request!!!"),
+    LOOKUP_ERROR("This lookup value is not valid..."),
+    LOOKUP_PARAM_ERROR("You must choose a valid lookup type"),
 
     //MINECRAFT_CMD
     CMD_LINK("wje-link"),

--- a/src/main/java/locals/En.java
+++ b/src/main/java/locals/En.java
@@ -12,6 +12,9 @@ public enum En {
     MINECRAFT_ALREADYREGISTERED("This account is already confirmed..."),
     ACCOUNTSINFOS("Accounts informations"),
 
+    //REPLIES
+    LANG_CHANGED("Your language was changed"),
+
     //TITLES
     TITLE_ACCOUNT_CONFIRM("Your accounts confirmation"),
 
@@ -36,7 +39,7 @@ public enum En {
 
     //PLUGIN
     PLUGIN_HELLO("**The plugin `%s` %s**\n\n"),
-    PLUGIN_HELLO_ERROR("**`ERROR:` The plugin `%s` as encountered errors at initialisation**\n"),
+    PLUGIN_HELLO_ERROR("❌ **`ERROR:` The plugin `%s` as encountered errors at initialisation**\n"),
     PLUGIN_GOODBYE("**The plugin `%s` %s**\n\n"),
     PLUGIN_NAME("Name: `%s`"),
     PLUGIN_VERSION("Version: `%s`"),
@@ -47,14 +50,14 @@ public enum En {
     INFO_TRYREGISTERAGAIN("Try to do a registration request on Discord®."),
 
     //WARNS
-    WARN_REGISTRATIONDELAY("You're already registered, but the delay to confirm this account is overdue..."),
+    WARN_REGISTRATIONDELAY("❌ You're already registered, but the delay to confirm this account is overdue..."),
 
     //ERRORS
-    ERROR("ERROR"),
+    ERROR("❌ ERROR"),
     CONTACT_ADMNIN("Contact an administrator..."),
     CHECK_LOGS("**Check your `log` files!!!!**"),
     NOTREGISTERED("Your registration could not be fetched..."),
-    CMD_ERROR("Sorry... an error as occured during this request!!!"),
+    CMD_ERROR("❌ Sorry... an error as occured during this request!!!"),
 
     //MINECRAFT_CMD
     CMD_LINK("wje-link"),
@@ -63,19 +66,25 @@ public enum En {
     CMD_SERVER("server"),
     CMD_REGISTER("register"),
     CMD_LOOKUP("search"),
+    CMD_SETLOCAL("traduction"),
     //PARAMS
     PARAM_PJAVA("java-pseudo"),
     PARAM_PBEDR("bedrock-pseudo"),
     PARAM_REGISTR_LABELJ("Your Java pseudo"),
     PARAM_REGISTR_LABELB("Your Bedrock pseudo"),
     PARAM_LOOKUP_LABEL("The uuid or pseudo to search for"),
+    PARAM_LOCAL_SETLOCAL("language"),
+    PARAM_LOCAL_LABEL("Available language: ['FR, EN, ES']"),
     //DESC
     DESC_SERVER("Show the `Minecraft®` server informations."),
     DESC_REGISTR("Register on the `Minecraft®` server."),
     DESC_LOOKUP("Find `Minecraft®` players infos by uuid or pseudo."),
+    DESC_SETLOCAL("Change the display language.\n FR: francais, EN: english, ES: española."),
 
     //ACL
-    USERONLY_CMD("This command id reserved for Discord® registered users only."),
+    TEXTONLY_CMD("❌ This command is available only through textual channels."),
+    MEMBERONLY_CMD("❌ This command is available only through textual guild channels using this."),
+    USERONLY_CMD("❌ This command id reserved for Discord® registered users only."),
 
     ;
 

--- a/src/main/java/locals/Es.java
+++ b/src/main/java/locals/Es.java
@@ -29,6 +29,7 @@ public enum Es {
     CONNECTED_USERS("Joueurs connectés"), // à traduire
     SERVER_ACTIVITIES("🌿 Activités du serveur"), // à traduire
     TIME_METEO("Météo et temps"), // à traduire
+    SOME_EXAMPLES("Voici des examples"), // à traduire
 
     //REPLIES
     LANG_CHANGED("Tu idioma fue cambiado"), // à traduire
@@ -77,6 +78,8 @@ public enum Es {
     CHECK_LOGS("**Regarder les fichers de `log`!!!!**"), // à traduire
     NOTREGISTERED("Votre enregistrement n'a pas pu être retrouvé..."), // à traduire
     CMD_ERROR("❌ Désoler... une erreur est survenu lors de cette demande!!!"), // à traduire
+    LOOKUP_ERROR("Cette valeur de recherche n'est pas valide..."), // à traduire
+    LOOKUP_PARAM_ERROR("Vous devez choisir un type de recherche valide"), // à traduire
 
     //MINECRAFT_CMD
     CMD_LINK("wje-link"), // à traduire

--- a/src/main/java/locals/Es.java
+++ b/src/main/java/locals/Es.java
@@ -14,6 +14,7 @@ public enum Es {
 
     //REPLIES
     LANG_CHANGED("Tu idioma fue cambiado"), // à traduire
+    LANG_CURRENT("Su idioma es actualmente"), // à traduire
 
     //TITLES
     TITLE_ACCOUNT_CONFIRM("Confirmation de vos comptes"), // à traduire

--- a/src/main/java/locals/Es.java
+++ b/src/main/java/locals/Es.java
@@ -12,6 +12,9 @@ public enum Es {
     MINECRAFT_ALREADYREGISTERED("Ce compte est déja confirmé..."), // à traduire
     ACCOUNTSINFOS("Informations de comptes"), // à traduire
 
+    //REPLIES
+    LANG_CHANGED("Tu idioma fue cambiado"), // à traduire
+
     //TITLES
     TITLE_ACCOUNT_CONFIRM("Confirmation de vos comptes"), // à traduire
 
@@ -36,7 +39,7 @@ public enum Es {
 
     //PLUGIN
     PLUGIN_HELLO("**Le plugin `%s` %s **\n\n"), // à traduire
-    PLUGIN_HELLO_ERROR("**`ERREUR:` Le plugin `%s` a rencontré des `problèmes` à l'initialisation**\n"), // à traduire
+    PLUGIN_HELLO_ERROR("❌ **`ERREUR:` Le plugin `%s` a rencontré des `problèmes` à l'initialisation**\n"), // à traduire
     PLUGIN_GOODBYE("**Le plugin `%s` %s **\n\n"), // à traduire
     PLUGIN_NAME("Nom: `%s`"), // à traduire
     PLUGIN_VERSION("Version: `%s`"), // à traduire
@@ -47,14 +50,14 @@ public enum Es {
     INFO_TRYREGISTERAGAIN("Essayez de refaire une demande d'enregistrment sur Discord®."), // à traduire
 
     //WARNS
-    WARN_REGISTRATIONDELAY("Vous êtes bien enregistré, mais le délai pour confirmer ce compte est dépassé..."), // à traduire
+    WARN_REGISTRATIONDELAY("❌ Vous êtes bien enregistré, mais le délai pour confirmer ce compte est dépassé..."), // à traduire
 
     //ERRORS
-    ERROR("ERREUR"), // à traduire
+    ERROR("❌ ERREUR"), // à traduire
     CONTACT_ADMNIN("Contactez un admin..."), // à traduire
     CHECK_LOGS("**Regarder les fichers de `log`!!!!**"), // à traduire
     NOTREGISTERED("Votre enregistrement n'a pas pu être retrouvé..."), // à traduire
-    CMD_ERROR("Désoler... une erreur est survenu lors de cette demande!!!"), // à traduire
+    CMD_ERROR("❌ Désoler... une erreur est survenu lors de cette demande!!!"), // à traduire
 
     //MINECRAFT_CMD
     CMD_LINK("wje-link"), // à traduire
@@ -63,19 +66,25 @@ public enum Es {
     CMD_SERVER("serveur"), // à traduire
     CMD_REGISTER("enregistrer"), // à traduire
     CMD_LOOKUP("recherche"), // à traduire
+    CMD_SETLOCAL("traduccion"),
     //PARAMS
     PARAM_PJAVA("pseudo-java"), // à traduire
     PARAM_PBEDR("pseudo-bedrock"), // à traduire
     PARAM_REGISTR_LABELJ("Votre pseudo Java"), // à traduire
     PARAM_REGISTR_LABELB("Votre pseudo Bedrock"), // à traduire
     PARAM_LOOKUP_LABEL("Le uuid ou le pseudo de recherche"), // à traduire
+    PARAM_LOCAL_SETLOCAL("idioma"),
+    PARAM_LOCAL_LABEL("Idioma disponible: ['FR, EN, ES']"),
     //DESC
     DESC_SERVER("Afficher les informations du serveur `Minecraft®`."), // à traduire
     DESC_REGISTR("S'enregister sur le serveur `Minecraft®`."), // à traduire
     DESC_LOOKUP("Trouver des infos de joueurs Minecraft® par uuid ou pseudo."), // à traduire
+    DESC_SETLOCAL("Changer la langue d'affichage.\n FR: francais, EN: english, ES: española."), // à traduire
 
     //ACL
-    USERONLY_CMD("Cette commande est réservée aux utilisateurs enregistrés par Discord®."), // à traduire
+    TEXTONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels."), // à traduire
+    MEMBERONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuel de guild utilisant ce plugin."), // à traduire
+    USERONLY_CMD("❌ Cette commande est réservée aux utilisateurs enregistrés par Discord®."), // à traduire
 
     ;
 

--- a/src/main/java/locals/Es.java
+++ b/src/main/java/locals/Es.java
@@ -2,15 +2,33 @@ package locals;
 
 public enum Es {
     //GLOBAL
-    RAINY("pluvieux"), // à traduire
-    SUNNY("ensoleillé"), // à traduire
+    YES("Si"),
+    NO("No"),
+    RAINY("lluvioso"),
+    SUNNY("soleado"),
+    STORMY("tormentoso"),
+    DAY("Día"),
+    NIGHT("Noche"),
     NAME("nom"), // à traduire
-    VERSION("version"), // à traduire
+    VERSION("Version"), // à traduire
     ISACTIVE("est actif"), // à traduire
     ISINACTIVE("est inactif"), // à traduire
     DOREGISTER("Enregistrer vous sur le serveur Discord®"), // à traduire
     MINECRAFT_ALREADYREGISTERED("Ce compte est déja confirmé..."), // à traduire
     ACCOUNTSINFOS("Informations de comptes"), // à traduire
+    INFORMATION("Informations"), // à traduire
+    SERVER("Serveur"), // à traduire
+    WORLDS("Mondes"), // à traduire
+    DEVS("Développeurs"), // à traduire
+    PORT("Port"), // à traduire
+    ONLINE_MODE("Mode en ligne"), // à trauire
+    WHITELISTED("Whitelisted"), // à traduire
+    DEFAULT_GAMEMOD("Mode de jeu"), // à traduire
+    DESCRIPTION("Description"), // à traduire
+    CONNECTED_USER("Joueur connecté"), // à traduire
+    CONNECTED_USERS("Joueurs connectés"), // à traduire
+    SERVER_ACTIVITIES("🌿 Activités du serveur"), // à traduire
+    TIME_METEO("Météo et temps"), // à traduire
 
     //REPLIES
     LANG_CHANGED("Tu idioma fue cambiado"), // à traduire
@@ -84,8 +102,11 @@ public enum Es {
 
     //ACL
     TEXTONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels."), // à traduire
-    MEMBERONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuel de guild utilisant ce plugin."), // à traduire
+    GUILDONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuel de guild utilisant ce plugin."), // à traduire
     USERONLY_CMD("❌ Cette commande est réservée aux utilisateurs enregistrés par Discord®."), // à traduire
+
+    //MISC
+    SERVER_IS_UP("Le serveur est up and running boyyssss!"), // à traduire
 
     ;
 

--- a/src/main/java/locals/Fr.java
+++ b/src/main/java/locals/Fr.java
@@ -14,6 +14,8 @@ public enum Fr {
 
     //REPLIES
     LANG_CHANGED("Votre langue a été modifié"),
+    LANG_CURRENT("Votre langue est actuellement"),
+
 
     //TITLES
     TITLE_ACCOUNT_CONFIRM("Confirmation de vos comptes"),

--- a/src/main/java/locals/Fr.java
+++ b/src/main/java/locals/Fr.java
@@ -2,15 +2,33 @@ package locals;
 
 public enum Fr {
     //GLOBAL
+    YES("Oui"),
+    NO("Non"),
     RAINY("pluvieux"),
     SUNNY("ensoleillé"),
+    STORMY("orageux"),
+    DAY("Jour"),
+    NIGHT("Nuit"),
     NAME("nom"),
-    VERSION("version"),
+    VERSION("Version"),
     ISACTIVE("est actif"),
     ISINACTIVE("est inactif"),
     DOREGISTER("Enregistrer vous sur le serveur Discord®"),
     MINECRAFT_ALREADYREGISTERED("Ce compte est déja confirmé..."),
     ACCOUNTSINFOS("Informations de comptes"),
+    INFORMATION("Informations"),
+    SERVER("Serveur"),
+    WORLDS("Mondes"),
+    DEVS("Développeurs"),
+    PORT("Port"),
+    ONLINE_MODE("Mode en ligne"),
+    WHITELISTED("Whitelisted"),
+    DEFAULT_GAMEMOD("Mode de jeu default"),
+    DESCRIPTION("Description"),
+    CONNECTED_USER("Joueur connecté"),
+    CONNECTED_USERS("Joueurs connectés"),
+    SERVER_ACTIVITIES("🌿 Activités du serveur"),
+    TIME_METEO("Météo et temps"),
 
     //REPLIES
     LANG_CHANGED("Votre langue a été modifié"),
@@ -85,8 +103,11 @@ public enum Fr {
 
     //ACL
     TEXTONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels."),
-    MEMBERONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels de guild utilisant ce plugin."),
+    GUILDONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels de guild utilisant ce plugin."),
     USERONLY_CMD("❌ Cette commande est réservée aux utilisateurs enregistrés par Discord®."),
+
+    //MISC
+    SERVER_IS_UP("Le serveur est up and running boyyssss!"),
 
     ;
 

--- a/src/main/java/locals/Fr.java
+++ b/src/main/java/locals/Fr.java
@@ -12,6 +12,9 @@ public enum Fr {
     MINECRAFT_ALREADYREGISTERED("Ce compte est déja confirmé..."),
     ACCOUNTSINFOS("Informations de comptes"),
 
+    //REPLIES
+    LANG_CHANGED("Votre langue a été modifié"),
+
     //TITLES
     TITLE_ACCOUNT_CONFIRM("Confirmation de vos comptes"),
 
@@ -36,7 +39,7 @@ public enum Fr {
 
     //PLUGIN
     PLUGIN_HELLO("**Le plugin `%s` %s **\n\n"),
-    PLUGIN_HELLO_ERROR("**`ERREUR:` Le plugin `%s` a rencontré des `problèmes` à l'initialisation**\n"),
+    PLUGIN_HELLO_ERROR("❌ **`ERREUR:` Le plugin `%s` a rencontré des `problèmes` à l'initialisation**\n"),
     PLUGIN_GOODBYE("**Le plugin `%s` %s **\n\n"),
     PLUGIN_NAME("Nom: `%s`"),
     PLUGIN_VERSION("Version: `%s`"),
@@ -47,14 +50,14 @@ public enum Fr {
     INFO_TRYREGISTERAGAIN("Essayez de refaire une demande d'enregistrment sur Discord®."),
 
     //WARNS
-    WARN_REGISTRATIONDELAY("Vous êtes bien enregistré, mais le délai pour confirmer ce compte est dépassé..."),
+    WARN_REGISTRATIONDELAY("❌ Vous êtes bien enregistré, mais le délai pour confirmer ce compte est dépassé..."),
 
     //ERRORS
-    ERROR("ERREUR"),
+    ERROR("❌ ERREUR"),
     CONTACT_ADMNIN("Contactez un admin..."),
     CHECK_LOGS("**Regarder les fichers de `log`!!!!**"),
     NOTREGISTERED("Votre enregistrement n'a pas pu être retrouvé..."),
-    CMD_ERROR("Désoler... une erreur est survenu lors de cette demande!!!"),
+    CMD_ERROR("❌ Désoler... une erreur est survenu lors de cette demande!!!"),
 
     //MINECRAFT_CMD
     CMD_LINK("wje-link"),
@@ -63,19 +66,25 @@ public enum Fr {
     CMD_SERVER("serveur"),
     CMD_REGISTER("enregistrer"),
     CMD_LOOKUP("recherche"),
+    CMD_SETLOCAL("langue"),
     //PARAMS
     PARAM_PJAVA("pseudo-java"),
     PARAM_PBEDR("pseudo-bedrock"),
     PARAM_REGISTR_LABELJ("Votre pseudo Java"),
     PARAM_REGISTR_LABELB("Votre pseudo Bedrock"),
     PARAM_LOOKUP_LABEL("Le uuid ou le pseudo de recherche"),
+    PARAM_LOCAL_SETLOCAL("langue"),
+    PARAM_LOCAL_LABEL("Language disponible: ['FR, EN, ES']"),
     //DESC
     DESC_SERVER("Afficher les informations du serveur `Minecraft®`."),
     DESC_REGISTR("S'enregister sur le serveur `Minecraft®`."),
     DESC_LOOKUP("Trouver des infos de joueurs Minecraft® par uuid ou pseudo."),
+    DESC_SETLOCAL("Changer la langue d'affichage.\n FR: francais, EN: english, ES: española."),
 
     //ACL
-    USERONLY_CMD("Cette commande est réservée aux utilisateurs enregistrés par Discord®."),
+    TEXTONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels."),
+    MEMBERONLY_CMD("❌ Cette commande est disponible seulement dans les cannaux textuels de guild utilisant ce plugin."),
+    USERONLY_CMD("❌ Cette commande est réservée aux utilisateurs enregistrés par Discord®."),
 
     ;
 

--- a/src/main/java/locals/Fr.java
+++ b/src/main/java/locals/Fr.java
@@ -29,6 +29,7 @@ public enum Fr {
     CONNECTED_USERS("Joueurs connectés"),
     SERVER_ACTIVITIES("🌿 Activités du serveur"),
     TIME_METEO("Météo et temps"),
+    SOME_EXAMPLES("Voici des examples"),
 
     //REPLIES
     LANG_CHANGED("Votre langue a été modifié"),
@@ -78,6 +79,8 @@ public enum Fr {
     CHECK_LOGS("**Regarder les fichers de `log`!!!!**"),
     NOTREGISTERED("Votre enregistrement n'a pas pu être retrouvé..."),
     CMD_ERROR("❌ Désoler... une erreur est survenu lors de cette demande!!!"),
+    LOOKUP_ERROR("Cette valeur de recherche n'est pas valide..."),
+    LOOKUP_PARAM_ERROR("Vous devez choisir un type de rcherche valide"),
 
     //MINECRAFT_CMD
     CMD_LINK("wje-link"),

--- a/src/main/java/locals/Lang.java
+++ b/src/main/java/locals/Lang.java
@@ -3,10 +3,12 @@ package locals;
 public enum Lang {
     FR("FR"),
     EN("EN"),
-    EN_FR("EN_FR"),
+    ES("ES"),
     FR_EN("FR_EN"),
-
-    ;
+    FR_ES("FR_ES"),
+    EN_FR("EN_FR"),
+    ES_FR("ES_FR"),
+    ES_EN("ES_EN");
 
     public final String value;
 

--- a/src/main/java/locals/LocalManager.java
+++ b/src/main/java/locals/LocalManager.java
@@ -3,19 +3,22 @@ package locals;
 import java.util.logging.Logger;
 
 import configs.ConfigManager;
+import main.WhitelistJe;
 import services.sentry.SentryService;
 
 public class LocalManager {
-    
+
     private Logger logger;
+    private WhitelistJe plugin;
     private ConfigManager configs;
     private String defaultLang = "FR";
     private String nextInteractionLang = "FR";
 
-    public LocalManager(ConfigManager configs) {
+    public LocalManager(WhitelistJe plugin) {
         this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
 
-        this.configs = configs;
+        this.plugin = plugin;
+        this.configs = plugin.getConfigManager();
         this.setNextLang(this.configs.get("defaultLang", "FR"));
     }
 

--- a/src/main/java/locals/LocalManager.java
+++ b/src/main/java/locals/LocalManager.java
@@ -154,7 +154,7 @@ public class LocalManager {
         lang = lang.toUpperCase();
 
         try {
-            if (Lang.valueOf(lang).value == lang) {
+            if (Lang.valueOf(lang).value.equals(lang)) {
                 return true;
             }
         } catch (Exception e) {

--- a/src/main/java/locals/LocalManager.java
+++ b/src/main/java/locals/LocalManager.java
@@ -150,7 +150,7 @@ public class LocalManager {
     }
 
     public final Boolean isSupported(String lang) {
-        final String msg = "Is not a supported language: " + lang;
+        final String msg = "Is not a supported traduction: " + lang;
         lang = lang.toUpperCase();
 
         try {

--- a/src/main/java/locals/LocalManager.java
+++ b/src/main/java/locals/LocalManager.java
@@ -153,9 +153,6 @@ public class LocalManager {
         final String msg = "Is not a supported language: " + lang;
         lang = lang.toUpperCase();
 
-        logger.info("newLang: " + lang);
-        logger.info(Lang.valueOf(lang).value);
-
         try {
             if (Lang.valueOf(lang).value == lang) {
                 return true;

--- a/src/main/java/locals/LocalManager.java
+++ b/src/main/java/locals/LocalManager.java
@@ -3,18 +3,20 @@ package locals;
 import java.util.logging.Logger;
 
 import configs.ConfigManager;
-
 import services.sentry.SentryService;
 
 public class LocalManager {
-
+    
     private Logger logger;
+    private ConfigManager configs;
     private String defaultLang = "FR";
     private String nextInteractionLang = "FR";
 
     public LocalManager(ConfigManager configs) {
-        this.setNextLang(configs.get("defaultLang", "FR"));
         this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
+
+        this.configs = configs;
+        this.setNextLang(this.configs.get("defaultLang", "FR"));
     }
 
     public final void setNextLang(String lang) {

--- a/src/main/java/main/WhitelistJe.java
+++ b/src/main/java/main/WhitelistJe.java
@@ -25,7 +25,6 @@ import services.sentry.SentryService;
 public final class WhitelistJe extends JavaPlugin implements Listener {
 
     private Logger logger;
-    public static LocalManager LOCALES;
     private BukkitManager bukkitManager;
     private GuildManager guildManager;
     private ConfigManager configManager;
@@ -36,7 +35,9 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
     private JSONArray playersAllowed = new JSONArray();
     private SentryService sentryService;
 
-    public String getfiglet() {
+    public static LocalManager LOCALES;
+
+    public final String getfiglet() {
         String figlet = """
 
                  __       __  __        __    __                __  __              __               _____
@@ -64,7 +65,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
     }
 
-    public String getPluginInfos(boolean toConsole) {
+    public final String getPluginInfos(boolean toConsole) {
         final StringBuilder sb = new StringBuilder();
         final String devName = toConsole
                 ? "@xXx-RaFuX#1345"
@@ -91,22 +92,16 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
     }
 
     @Override
-    public void onEnable() {
-        logger.info("xxxxxxxxxxxxxxxxxxxxxxxxxx");
+    public final void onEnable() {
         ITransaction transaction = Sentry.startTransaction("onEnable", "configurePlugin");
-        final StringBuilder sb = new StringBuilder();
-        
         transaction.setStatus(SpanStatus.INTERNAL_ERROR);
-        SentryService.captureEx(new Exception("enaaabllbe"));
 
-        logger.info("oooooooooooooooooooooooooooo");
+        final StringBuilder sb = new StringBuilder();
 
         try {
             configManager = new ConfigManager();
-            LOCALES = new LocalManager(configManager);
             sentryService = new SentryService(this);
-            transaction = sentryService.createTx("onEnable", "configurePlugin");
-
+            LOCALES = new LocalManager(configManager);
             daoManager = new DaoManager(configManager, this);
             discordManager = new DiscordManager(this);
             guildManager = new GuildManager(discordManager.getGuild(), this);
@@ -123,7 +118,8 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
             guildManager.getAdminChannel()
                 .sendMessage(sb.toString()).submit(true);
 
-            Logger.getLogger("WhiteList-Je").info(this.getfiglet());
+            logger.info("oooooooooooooooooooooooooooo");
+            logger.info(this.getfiglet());
 
         } catch (Exception e) {
             try {
@@ -155,7 +151,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
     }
 
     @Override
-    public void onDisable() {
+    public final void onDisable() {
         final StringBuilder sb = new StringBuilder();
         
         sb.append(String.format(
@@ -168,31 +164,31 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
             .sendMessage(sb.toString()).submit(true);
     }
 
-    public DiscordManager getDiscordManager() {
+    public final DiscordManager getDiscordManager() {
         return this.discordManager;
     }
 
-    public DaoManager getDaoManager() {
+    public final DaoManager getDaoManager() {
         return this.daoManager;
     }
 
-    public ConfigManager getConfigManager() {
-        return this.configManager;
+    public final ConfigManager getConfigManager() {
+        return configManager;
     }
 
-    public GuildManager getGuildManager() {
+    public final GuildManager getGuildManager() {
         return this.guildManager;
     }
 
-    public BukkitManager getBukkitManager() {
+    public final BukkitManager getBukkitManager() {
         return this.bukkitManager;
     }
 
-    public SentryService getSentryService() {
+    public final SentryService getSentryService() {
         return this.sentryService;
     }
 
-    public JSONArray updateAllPlayers() {
+    public final JSONArray updateAllPlayers() {
         ISpan process = getSentryService().findWithuniqueName("onEnable")
                 .startChild("updateAllPlayers");
 
@@ -213,7 +209,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         return this.players;
     }
 
-    public JSONArray updateAllowedPlayers() {
+    public final JSONArray updateAllowedPlayers() {
         ISpan process = getSentryService().findWithuniqueName("onEnable")
                 .startChild("updateAllowedPlayers");
 
@@ -232,7 +228,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         return this.playersAllowed;
     }
 
-    public Integer getPlayerId(UUID uuid) {
+    public final Integer getPlayerId(UUID uuid) {
         Integer userId = -1;
         this.updateAllPlayers();
 
@@ -257,7 +253,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         return userId;
     }
 
-    public Integer playerIsAllowed(UUID uuid) {
+    public final Integer playerIsAllowed(UUID uuid) {
         Integer allowedUserId = -1;
         this.updateAllowedPlayers();
 
@@ -282,7 +278,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         return allowedUserId;
     }
 
-    public Integer playerIsConfirmed(UUID uuid) {
+    public final Integer playerIsConfirmed(UUID uuid) {
         Integer allowedUserId = -1;
         this.updateAllowedPlayers();
 
@@ -308,7 +304,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         return allowedUserId;
     }
 
-    public JSONObject getMinecraftDataJson(UUID uuid) {
+    public final JSONObject getMinecraftDataJson(UUID uuid) {
         JSONObject data = null;
         this.updateAllPlayers();
 
@@ -333,7 +329,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         return data;
     }
 
-    public boolean deletePlayerRegistration(UUID UUID) {
+    public final boolean deletePlayerRegistration(UUID UUID) {
         try {
             if (UUID == null) {
                 return false;
@@ -360,7 +356,7 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
 
     }
 
-    public boolean deleteAllPlayerData(UUID UUID) {
+    public final boolean deleteAllPlayerData(UUID UUID) {
         try {
             if (UUID == null) {
                 return false;

--- a/src/main/java/main/WhitelistJe.java
+++ b/src/main/java/main/WhitelistJe.java
@@ -94,17 +94,17 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
     @Override
     public final void onEnable() {
         ITransaction transaction = Sentry.startTransaction("onEnable", "configurePlugin");
-        transaction.setStatus(SpanStatus.INTERNAL_ERROR);
-
         final StringBuilder sb = new StringBuilder();
 
         try {
-            configManager = new ConfigManager();
+            this.configManager = new ConfigManager();
+            LOCALES = new LocalManager(this);
             sentryService = new SentryService(this);
-            LOCALES = new LocalManager(configManager);
-            daoManager = new DaoManager(configManager, this);
+            transaction = sentryService.createTx("onEnable", "configurePlugin");
+
+            daoManager = new DaoManager(this);
             discordManager = new DiscordManager(this);
-            guildManager = new GuildManager(discordManager.getGuild(), this);
+            guildManager = new GuildManager(this);
             bukkitManager = new BukkitManager(this);
 
             updateAllPlayers();
@@ -118,8 +118,8 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
             guildManager.getAdminChannel()
                 .sendMessage(sb.toString()).submit(true);
 
-            logger.info("oooooooooooooooooooooooooooo");
             logger.info(this.getfiglet());
+
 
         } catch (Exception e) {
             try {

--- a/src/main/java/main/WhitelistJe.java
+++ b/src/main/java/main/WhitelistJe.java
@@ -25,7 +25,6 @@ import services.sentry.SentryService;
 public final class WhitelistJe extends JavaPlugin implements Listener {
 
     private Logger logger;
-    public WhitelistJe instance;
     public static LocalManager LOCALES;
     private BukkitManager bukkitManager;
     private GuildManager guildManager;
@@ -93,11 +92,16 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
+        logger.info("xxxxxxxxxxxxxxxxxxxxxxxxxx");
         ITransaction transaction = Sentry.startTransaction("onEnable", "configurePlugin");
         final StringBuilder sb = new StringBuilder();
+        
+        transaction.setStatus(SpanStatus.INTERNAL_ERROR);
+        SentryService.captureEx(new Exception("enaaabllbe"));
+
+        logger.info("oooooooooooooooooooooooooooo");
 
         try {
-            instance = this;
             configManager = new ConfigManager();
             LOCALES = new LocalManager(configManager);
             sentryService = new SentryService(this);

--- a/src/main/java/main/WhitelistJe.java
+++ b/src/main/java/main/WhitelistJe.java
@@ -97,45 +97,41 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         final StringBuilder sb = new StringBuilder();
 
         try {
-            logger.info("aaa");
             this.configManager = new ConfigManager();
-            logger.info("bbb");
+            logger.info("LOADED: ConfigManager");
+            
             LOCALES = new LocalManager(this);
-            logger.info("ccc");
+            logger.info("LOADED: LocalManager");
+            
             sentryService = new SentryService(this);
-            logger.info("ddd");
             transaction = sentryService.createTx("onEnable", "configurePlugin");
-            logger.info("eee");
-
+            logger.info("LOADED: SentryService");
+            
             daoManager = new DaoManager(this);
-            logger.info("fff");
+            logger.info("LOADED: DaoManager");
+            
             discordManager = new DiscordManager(this);
-            logger.info("ggg");
+            logger.info("LOADED: DiscordManager");
+            
             guildManager = new GuildManager(this);
-            logger.info("hhh");
+            logger.info("LOADED: GuildManager");
+            
             bukkitManager = new BukkitManager(this);
-            logger.info("iii");
+            logger.info("LOADED: BukkitManager");
 
             updateAllPlayers();
-
-            logger.info("jjj");
+            logger.info("UPDATED PLAYERS CACHE");
 
             sb.append(String.format(
                 LOCALES.translate("PLUGIN_HELLO"),
                 this.getName(), LOCALES.translate("ISACTIVE")
             ));
-
-            logger.info("kkk");
-            sb.append(getPluginInfos(false));
-            logger.info("lll");
             
+            sb.append(getPluginInfos(false));
             guildManager.getAdminChannel()
                 .sendMessage(sb.toString()).submit(true);
 
-            logger.info("mmm");
-
             logger.info(this.getfiglet());
-
 
         } catch (Exception e) {
             try {

--- a/src/main/java/main/WhitelistJe.java
+++ b/src/main/java/main/WhitelistJe.java
@@ -97,26 +97,42 @@ public final class WhitelistJe extends JavaPlugin implements Listener {
         final StringBuilder sb = new StringBuilder();
 
         try {
+            logger.info("aaa");
             this.configManager = new ConfigManager();
+            logger.info("bbb");
             LOCALES = new LocalManager(this);
+            logger.info("ccc");
             sentryService = new SentryService(this);
+            logger.info("ddd");
             transaction = sentryService.createTx("onEnable", "configurePlugin");
+            logger.info("eee");
 
             daoManager = new DaoManager(this);
+            logger.info("fff");
             discordManager = new DiscordManager(this);
+            logger.info("ggg");
             guildManager = new GuildManager(this);
+            logger.info("hhh");
             bukkitManager = new BukkitManager(this);
+            logger.info("iii");
 
             updateAllPlayers();
+
+            logger.info("jjj");
 
             sb.append(String.format(
                 LOCALES.translate("PLUGIN_HELLO"),
                 this.getName(), LOCALES.translate("ISACTIVE")
             ));
+
+            logger.info("kkk");
             sb.append(getPluginInfos(false));
+            logger.info("lll");
             
             guildManager.getAdminChannel()
                 .sendMessage(sb.toString()).submit(true);
+
+            logger.info("mmm");
 
             logger.info(this.getfiglet());
 

--- a/src/main/java/services/sentry/SentryService.java
+++ b/src/main/java/services/sentry/SentryService.java
@@ -17,25 +17,26 @@ import io.sentry.protocol.User;
 import main.WhitelistJe;
 
 public class SentryService {
-
+  
+  private Logger logger;
+  private static User user;
+  private WhitelistJe plugin;
+  private static WhitelistJe main;
   private boolean enabled = true;
   private String debugMode = "debug";
-  private WhitelistJe plugin;
-  private static User user;
+  
   HashMap<Integer, ITransaction>  pendingTransactions = new HashMap<Integer, ITransaction>();
-  private Logger logger;
-  private static WhitelistJe main;
 
   public SentryService(WhitelistJe plugin) {
     this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
 
     this.plugin = plugin;
-    main = this.plugin;
+    SentryService.main = this.plugin;
     
     final User user = new User();
-    final String id = this.plugin.getConfigManager().get("discordServerId", "discordServerId");
-    final String username = this.plugin.getConfigManager().get("discordOwnerId", "discordOwnerId");
-    final String ipAddress = this.plugin.getConfigManager().get("paperMcIp", "paperMcIp");
+    final String id = this.plugin.getConfigManager().get("discordServerId", "?discordServerId?");
+    final String username = this.plugin.getConfigManager().get("discordOwnerId", "?discordOwnerId?");
+    final String ipAddress = this.plugin.getConfigManager().get("paperMcIp", "?paperMcIp?");
     final String envType = this.plugin.getConfigManager().get("envType", "?envType?");
     final String release = this.plugin.getConfigManager().get("pluginVersion", "?release?") + "@" + envType;
     

--- a/src/main/java/services/sentry/SentryService.java
+++ b/src/main/java/services/sentry/SentryService.java
@@ -144,7 +144,7 @@ public class SentryService {
     Exception ex = new Exception(error.getMessage() + userToString());
     err.printStackTrace();
 
-    if(!main.getConfigManager().get("envType", "production").equals("devMode"))
+    if(!main.getConfigManager().get("envType", "production").equals("dev"))
       return Sentry.captureException(ex);
 
     return null;

--- a/src/main/java/services/sentry/SentryService.java
+++ b/src/main/java/services/sentry/SentryService.java
@@ -18,36 +18,17 @@ import main.WhitelistJe;
 
 public class SentryService {
 
-  private String debugMode = "debug";
   private boolean enabled = true;
+  private String debugMode = "debug";
   private WhitelistJe plugin;
   private static User user;
   HashMap<Integer, ITransaction>  pendingTransactions = new HashMap<Integer, ITransaction>();
+  private Logger logger;
   private static WhitelistJe main;
 
-  @Override
-  protected void finalize() throws Throwable {
-      finalyzeAllTransaction();
-  }
-
-  private void finalyzeAllTransaction() {
-    try {
-      if(pendingTransactions != null &&  getTxSize() > 0)
-      pendingTransactions.forEach((key,tx) -> {
-        try {
-          tx.setData("finalStatus", "with destruction");
-          tx.finish();
-        } catch (Exception e) {
-          captureEx(e);
-        }
-      });
-    } catch (Exception e) {
-      captureEx(e);
-    }
-
-  }
-
   public SentryService(WhitelistJe plugin) {
+    this.logger = Logger.getLogger("WJE:" + this.getClass().getSimpleName());
+
     this.plugin = plugin;
     main = this.plugin;
     
@@ -77,6 +58,27 @@ public class SentryService {
     });
   }
 
+  @Override
+  protected void finalize() throws Throwable {
+      finalyzeAllTransaction();
+  }
+
+  private void finalyzeAllTransaction() {
+    try {
+      if(pendingTransactions != null &&  getTxSize() > 0)
+      pendingTransactions.forEach((key,tx) -> {
+        try {
+          tx.setData("finalStatus", "with destruction");
+          tx.finish();
+        } catch (Exception e) {
+          captureEx(e);
+        }
+      });
+    } catch (Exception e) {
+      captureEx(e);
+    }
+
+  }
   
   public ITransaction createTx(String name, String operation) {
     final Integer size = getTxSize();
@@ -142,6 +144,7 @@ public class SentryService {
   public static @NotNull SentryId captureEx(Throwable error) {
     Exception err = new Exception(error.getMessage());
     Exception ex = new Exception(error.getMessage() + userToString());
+    Logger.getLogger("WJE: SentryService").warning("WARNING: ");
     err.printStackTrace();
 
     if(!main.getConfigManager().get("envType", "production").equals("dev"))


### PR DESCRIPTION
Classe de base servant a faire des classe de commande Discord®
Rend disponible les commandes pour changer la langue des utilisateurs enregistrer => /langue
Traduite:
/server
/langue
/recherche
buckitManager-> getServerInfos()
klke autre string hors commandes

À venir:
/register (incomplete pour l'instant)
/wje-link (MC)
les autres string par-ci par-là